### PR TITLE
US-0000041: Calculation Matrix test

### DIFF
--- a/vlocity/CalculationMatrixVersion/CM2Version4/CM2Version4_DataPack.json
+++ b/vlocity/CalculationMatrixVersion/CM2Version4/CM2Version4_DataPack.json
@@ -1,0 +1,24 @@
+{
+    "%vlocity_namespace%__CalculationMatrixId__c": {
+        "Name": "CopadoTestCM2",
+        "VlocityDataPackType": "VlocityLookupMatchingKeyObject",
+        "VlocityLookupRecordSourceKey": "%vlocity_namespace%__CalculationMatrix__c/CopadoTestCM2",
+        "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrix__c"
+    },
+    "%vlocity_namespace%__CalculationMatrixId__r.Name": "CopadoTestCM2",
+    "%vlocity_namespace%__CalculationMatrixRow__c": "CM2Version4_Rows.json",
+    "%vlocity_namespace%__CurrentStatus__c": "Active",
+    "%vlocity_namespace%__EndDateTime__c": "",
+    "%vlocity_namespace%__GlobalKey__c": "CM2Version4",
+    "%vlocity_namespace%__GroupKeyValue__c": "",
+    "%vlocity_namespace%__MatrixUseLongOutput__c": false,
+    "%vlocity_namespace%__Priority__c": 4,
+    "%vlocity_namespace%__StartDateTime__c": "2022-08-04T03:14:42.000Z",
+    "%vlocity_namespace%__SubGroupKeyValue__c": "",
+    "%vlocity_namespace%__UseLongOutput__c": false,
+    "%vlocity_namespace%__VersionNumber__c": 4,
+    "Name": "CM2Version4",
+    "VlocityDataPackType": "SObject",
+    "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixVersion__c",
+    "VlocityRecordSourceKey": "%vlocity_namespace%__CalculationMatrixVersion__c/4/%vlocity_namespace%__CalculationMatrix__c/CopadoTestCM2"
+}

--- a/vlocity/CalculationMatrixVersion/CM2Version4/CM2Version4_ParentKeys.json
+++ b/vlocity/CalculationMatrixVersion/CM2Version4/CM2Version4_ParentKeys.json
@@ -1,0 +1,3 @@
+[
+    "CalculationMatrix/CopadoTestCM2"
+]

--- a/vlocity/CalculationMatrixVersion/CM2Version4/CM2Version4_Rows.json
+++ b/vlocity/CalculationMatrixVersion/CM2Version4/CM2Version4_Rows.json
@@ -1,0 +1,103 @@
+[
+    {
+        "%vlocity_namespace%__CalculationMatrixVersionId__c": {
+            "%vlocity_namespace%__CalculationMatrixId__r.Name": "CopadoTestCM2",
+            "%vlocity_namespace%__VersionNumber__c": 4,
+            "VlocityDataPackType": "VlocityMatchingKeyObject",
+            "VlocityMatchingRecordSourceKey": "%vlocity_namespace%__CalculationMatrixVersion__c/4/%vlocity_namespace%__CalculationMatrix__c/CopadoTestCM2",
+            "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixVersion__c"
+        },
+        "%vlocity_namespace%__InputData__c": {
+            "columnKey": "92f202",
+            "dataType": "Text",
+            "displayOrder": 2,
+            "headerType": "Output",
+            "label": null,
+            "lineItemId": null,
+            "listValues": null,
+            "name": "Check dev2"
+        },
+        "Name": "Header",
+        "VlocityDataPackType": "SObject",
+        "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixRow__c"
+    },
+    {
+        "%vlocity_namespace%__CalculationMatrixVersionId__c": {
+            "%vlocity_namespace%__CalculationMatrixId__r.Name": "CopadoTestCM2",
+            "%vlocity_namespace%__VersionNumber__c": 4,
+            "VlocityDataPackType": "VlocityMatchingKeyObject",
+            "VlocityMatchingRecordSourceKey": "%vlocity_namespace%__CalculationMatrixVersion__c/4/%vlocity_namespace%__CalculationMatrix__c/CopadoTestCM2",
+            "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixVersion__c"
+        },
+        "%vlocity_namespace%__InputData__c": {
+            "columnKey": "bc2aab",
+            "dataType": "Text",
+            "displayOrder": 1,
+            "headerType": "Input",
+            "label": null,
+            "lineItemId": null,
+            "listValues": null,
+            "name": "Check dev1"
+        },
+        "Name": "Header",
+        "VlocityDataPackType": "SObject",
+        "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixRow__c"
+    },
+    {
+        "%vlocity_namespace%__CalculationMatrixVersionId__c": {
+            "%vlocity_namespace%__CalculationMatrixId__r.Name": "CopadoTestCM2",
+            "%vlocity_namespace%__VersionNumber__c": 4,
+            "VlocityDataPackType": "VlocityMatchingKeyObject",
+            "VlocityMatchingRecordSourceKey": "%vlocity_namespace%__CalculationMatrixVersion__c/4/%vlocity_namespace%__CalculationMatrix__c/CopadoTestCM2",
+            "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixVersion__c"
+        },
+        "%vlocity_namespace%__InputData__c": {
+            "Check dev1": "Can you"
+        },
+        "%vlocity_namespace%__OutputData__c": {
+            "Check dev2": "See this"
+        },
+        "%vlocity_namespace%__StartDateTime__c": "2022-08-04T03:14:42.000Z",
+        "Name": "fafaedb632b8c195bcb1460daf382104",
+        "VlocityDataPackType": "SObject",
+        "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixRow__c"
+    },
+    {
+        "%vlocity_namespace%__CalculationMatrixVersionId__c": {
+            "%vlocity_namespace%__CalculationMatrixId__r.Name": "CopadoTestCM2",
+            "%vlocity_namespace%__VersionNumber__c": 4,
+            "VlocityDataPackType": "VlocityMatchingKeyObject",
+            "VlocityMatchingRecordSourceKey": "%vlocity_namespace%__CalculationMatrixVersion__c/4/%vlocity_namespace%__CalculationMatrix__c/CopadoTestCM2",
+            "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixVersion__c"
+        },
+        "%vlocity_namespace%__InputData__c": {
+            "Check dev1": "Foo"
+        },
+        "%vlocity_namespace%__OutputData__c": {
+            "Check dev2": "Bar"
+        },
+        "%vlocity_namespace%__StartDateTime__c": "2022-08-04T03:14:42.000Z",
+        "Name": "0e9e91b17fe586feb77ab1495dbba756",
+        "VlocityDataPackType": "SObject",
+        "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixRow__c"
+    },
+    {
+        "%vlocity_namespace%__CalculationMatrixVersionId__c": {
+            "%vlocity_namespace%__CalculationMatrixId__r.Name": "CopadoTestCM2",
+            "%vlocity_namespace%__VersionNumber__c": 4,
+            "VlocityDataPackType": "VlocityMatchingKeyObject",
+            "VlocityMatchingRecordSourceKey": "%vlocity_namespace%__CalculationMatrixVersion__c/4/%vlocity_namespace%__CalculationMatrix__c/CopadoTestCM2",
+            "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixVersion__c"
+        },
+        "%vlocity_namespace%__InputData__c": {
+            "Check dev1": "Hello"
+        },
+        "%vlocity_namespace%__OutputData__c": {
+            "Check dev2": "World"
+        },
+        "%vlocity_namespace%__StartDateTime__c": "2022-08-04T03:14:42.000Z",
+        "Name": "c4848cc7a8a6356bdfaad3009f565743",
+        "VlocityDataPackType": "SObject",
+        "VlocityRecordSObjectType": "%vlocity_namespace%__CalculationMatrixRow__c"
+    }
+]


### PR DESCRIPTION
Hi @swongcopado , almost there with Calculation matrices but I found another issue.
Here I've made a new Calculation Matrix version in TEST sandbox, and enabled it. I rewind the US41 credentials back to test and then commit this version to the US41 feature branch. 
Via git diff (this PR), you can see that this change is compared against dev1 branch. But it's still not visible for back-promotion:
![image](https://user-images.githubusercontent.com/71686297/182757587-9d407099-b660-4650-a1f3-ef52eddc315c.png)
In contrast, the same is available for back-promote into dev2:
![image](https://user-images.githubusercontent.com/71686297/182757668-3550ea3d-443d-4575-8355-7a78e6b50728.png)
At the time of writing, the PR for US41 branch against dev1 and dev2 are identical.